### PR TITLE
Add support for imgs2/ series

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "img-labeler",
-  "version": "0.1.12",
+  "version": "0.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/drawing-canvas/drawing-canvas.component.ts
+++ b/src/app/drawing-canvas/drawing-canvas.component.ts
@@ -163,6 +163,7 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
       this.dimensions = this.maskSvc.getDimensions();
       if (this.dimensions) {
         this.svg = d3.select('.artboard').select('svg')
+          .attr('background-size', this.dimensions.width+'px '+this.dimensions.height+'px')
           .attr('height', this.dimensions.canvasHeight)
           .attr('width', this.dimensions.canvasWidth);
       }

--- a/src/app/drawing-canvas/drawing-canvas.component.ts
+++ b/src/app/drawing-canvas/drawing-canvas.component.ts
@@ -61,6 +61,8 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
     @ViewChild('url') url;
     @Output() Layers;
 
+    private dimensions;
+
     ngAfterViewInit(): void {
         this.maskSvc.setArtboard(this.artboard.nativeElement.innerHTML);
         this.setLayers();
@@ -86,15 +88,20 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
             this.panzoomModel = model;
         });
 
+        this.dimensions = this.maskSvc.getDimensions();
         this.svg = d3.select('.artboard').append('svg')
-            .attr('height', 950)
-            .attr('width', 1250);
+            .attr('background-size', this.dimensions.width+'px '+this.dimensions.height+'px')
+            .attr('height', this.dimensions.canvasHeight)
+            .attr('width', this.dimensions.canvasWidth);
 
         this.activatedRoute.queryParams.subscribe(params => {
             const userId = params.userId;
         });
 
         this.maskSvc.getImageUrl().subscribe(url => {
+            // Update canvas in case we need to change dimensions
+            this.updateCanvas();
+	    this.svg.style('background-size', this.dimensions.width+'px '+this.dimensions.height+'px');
             this.svg.style('background-image', `url('${url}')`);
         })
 
@@ -151,6 +158,15 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
 
     }
 
+    private updateCanvas(): void {
+      // Set canvas dimensions in case it changed
+      this.dimensions = this.maskSvc.getDimensions();
+      if (this.dimensions) {
+        this.svg = d3.select('.artboard').select('svg')
+          .attr('height', this.dimensions.canvasHeight)
+          .attr('width', this.dimensions.canvasWidth);
+      }
+    }
 
     private setLayers(): void {
         this.maskSvc.updateMask({ d3: this.svg, dom: this.artboard.nativeElement, loadedMask: this.loadedMask });

--- a/src/app/drawing-canvas/drawing-canvas.component.ts
+++ b/src/app/drawing-canvas/drawing-canvas.component.ts
@@ -99,9 +99,7 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
         });
 
         this.maskSvc.getImageUrl().subscribe(url => {
-            // Update canvas in case we need to change dimensions
             this.updateCanvas();
-	    this.svg.style('background-size', this.dimensions.width+'px '+this.dimensions.height+'px');
             this.svg.style('background-image', `url('${url}')`);
         })
 
@@ -163,9 +161,9 @@ export class DrawingCanvasComponent implements OnInit, AfterViewInit {
       this.dimensions = this.maskSvc.getDimensions();
       if (this.dimensions) {
         this.svg = d3.select('.artboard').select('svg')
-          .attr('background-size', this.dimensions.width+'px '+this.dimensions.height+'px')
           .attr('height', this.dimensions.canvasHeight)
           .attr('width', this.dimensions.canvasWidth);
+        this.svg.style('background-size', this.dimensions.width+'px '+this.dimensions.height+'px');
       }
     }
 

--- a/src/app/services/masking.service.ts
+++ b/src/app/services/masking.service.ts
@@ -38,8 +38,6 @@ export class MaskingService {
 
   public series = "imgs";
 
-  constructor() { }
-
   public setColor(index: number): void {
     this.currentColor = environment.colors[index];
   }

--- a/src/app/services/masking.service.ts
+++ b/src/app/services/masking.service.ts
@@ -38,6 +38,8 @@ export class MaskingService {
 
   public series = "imgs";
 
+  constructor() {
+  }
   public setColor(index: number): void {
     this.currentColor = environment.colors[index];
   }

--- a/src/app/services/masking.service.ts
+++ b/src/app/services/masking.service.ts
@@ -36,7 +36,6 @@ export class MaskingService {
     }
   };
 
-  public imgDimension = "imgs";
   public series = "imgs";
 
   constructor() { }
@@ -82,12 +81,11 @@ export class MaskingService {
   }
 
   public setDimensions(series: string): void {
-    this.imgDimension = series;
+    this.series = series;
   }
 
   public getDimensions(): void {
-    //console.log(this.imgDimensionConfig[this.imgDimension]);
-    return this.imgDimensionConfig[this.imgDimension];
+    return this.imgDimensionConfig[this.series];
   }
 
   public getImageUrl(): Observable<string> {

--- a/src/app/services/masking.service.ts
+++ b/src/app/services/masking.service.ts
@@ -20,8 +20,26 @@ export class MaskingService {
   public currentMaskUrl: string;
   public artboard: any;
 
-  constructor() {
-  }
+  public imgDimensionConfig = {
+    "imgs": {
+      width: 1164,
+      height: 874,
+      canvasWidth: 1250,
+      canvasHeight: 950
+    },
+    "imgs2": {
+      width: 1928,
+      height: 1208,
+      canvasWidth: 2014,
+      canvasHeight: 1284
+    }
+  };
+
+  public imgDimension = "imgs";
+  public series = "imgs";
+
+  constructor() { }
+
   public setColor(index: number): void {
     this.currentColor = environment.colors[index];
   }
@@ -50,6 +68,8 @@ export class MaskingService {
   }
 
   public setImageUrl(url: string): void {
+    var series = url.match(/[\w-]+\/[\w-]+\.(png|jpg)$/)[0].split("/")[0];
+    this.setDimensions(series);
     if (this.mask && this.mask.dom.children[0].children.length > 0) {
       this.modifyLayer(new LayerChange({ index: 0, type: 'clearAll' }));
       this.currentUrl = url;
@@ -58,6 +78,15 @@ export class MaskingService {
       this.currentUrl = url;
       this.imageUrl.next(url);
     }
+  }
+
+  public setDimensions(series: string): void {
+    this.imgDimension = series;
+  }
+
+  public getDimensions(): void {
+    //console.log(this.imgDimensionConfig[this.imgDimension]);
+    return this.imgDimensionConfig[this.imgDimension];
   }
 
   public getImageUrl(): Observable<string> {

--- a/src/app/services/masking.service.ts
+++ b/src/app/services/masking.service.ts
@@ -20,6 +20,7 @@ export class MaskingService {
   public currentMaskUrl: string;
   public artboard: any;
 
+  // TODO: This is a hack, do this right (using a model?)!
   public imgDimensionConfig = {
     "imgs": {
       width: 1164,

--- a/src/app/services/svgtopng.service.ts
+++ b/src/app/services/svgtopng.service.ts
@@ -66,7 +66,6 @@ export class SvgtopngService {
     let gitImage;
     if (!this.maskSvc.loadedMask()) {
       this.dimensions = this.maskSvc.getDimensions();
-console.log(this.dimensions);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);

--- a/src/app/services/svgtopng.service.ts
+++ b/src/app/services/svgtopng.service.ts
@@ -17,7 +17,6 @@ export class SvgtopngService {
     const holder = this;
     if (!this.maskSvc.loadedMask()) {
       this.dimensions = this.maskSvc.getDimensions();
-console.log(this.dimensions);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);

--- a/src/app/services/svgtopng.service.ts
+++ b/src/app/services/svgtopng.service.ts
@@ -11,19 +11,21 @@ import * as Jimp from 'jimp';
 export class SvgtopngService {
   public base64Mask: string;
   constructor(private maskSvc: MaskingService) { }
-
+  public dimensions;
 
   public save(): void {
     const holder = this;
     if (!this.maskSvc.loadedMask()) {
+      this.dimensions = this.maskSvc.getDimensions();
+console.log(this.dimensions);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);
       this.maskSvc.mask.d3.insert('polygon', ':first-child').attr('class', 'background').style('fill', '#808060')
-        .attr('points', '0,0,0,950,1250,950,1250,0').attr('shape-rendering', 'crispEdges');
+        .attr('points', '0,0,0,'+this.dimensions.canvasHeight+','+this.dimensions.canvasWidth+','+this.dimensions.canvasHeight+','+this.dimensions.canvasWidth+',0').attr('shape-rendering', 'crispEdges');
 
       svgSave.saveSvgAsPng(this.maskSvc.mask.dom.children[0], this.maskSvc.getCurrentImageUrl().match(/[\w-]+\.(png|jpg)/)[0]
-        .replace(/.(png|jpg)/, ''), { width: 1164, height: 874, top: 38, left: 43, encoderOptions: 0.0, scale: (1 / window.devicePixelRatio) }).then(
+        .replace(/.(png|jpg)/, ''), { width: this.dimensions.width, height: this.dimensions.height, top: 38, left: 43, encoderOptions: 0.0, scale: (1 / window.devicePixelRatio) }).then(
           () => {
             this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', this.maskSvc.currentOpacity);
             this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 1);
@@ -35,7 +37,7 @@ export class SvgtopngService {
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);
-      svgSave.svgAsPngUri(this.maskSvc.mask.dom.children[0], { width: 1164, height: 874, top: 38, left: 43, encoderOptions: 0.0, scale: (1 / window.devicePixelRatio) })
+      svgSave.svgAsPngUri(this.maskSvc.mask.dom.children[0], { width: this.dimensions.width, height: this.dimensions.height, top: 38, left: 43, encoderOptions: 0.0, scale: (1 / window.devicePixelRatio) })
         .then(uri => {
           Jimp.read(this.maskSvc.loadedMaskUrl(), (err, originalMask) => {
             Jimp.read(uri, (err, image) => {
@@ -64,13 +66,15 @@ export class SvgtopngService {
     const holder = this;
     let gitImage;
     if (!this.maskSvc.loadedMask()) {
+      this.dimensions = this.maskSvc.getDimensions();
+console.log(this.dimensions);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);
       this.maskSvc.mask.d3.insert('polygon', ':first-child').attr('class', 'background').style('fill', '#808060')
-        .attr('points', '0,0,0,950,1250,950,1250,0').attr('shape-rendering', 'crispEdges');
+        .attr('points', '0,0,0,'+this.dimensions.canvasHeight+','+this.dimensions.canvasWidth+','+this.dimensions.canvasHeight+','+this.dimensions.canvasWidth+',0').attr('shape-rendering', 'crispEdges');
       return svgSave.svgAsPngUri(this.maskSvc.mask.dom.children[0],
-        { width: 1164, height: 874, top: 38, left: 43, encoderOptions: 0.0 }).then(
+        { width: this.dimensions.width, height: this.dimensions.height, top: 38, left: 43, encoderOptions: 0.0 }).then(
           (image) => {
             gitImage = image;
             this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', this.maskSvc.currentOpacity);
@@ -84,7 +88,7 @@ export class SvgtopngService {
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('opacity', 1);
       this.maskSvc.mask.d3.selectAll('.completePoly').attr('visibility', 'visible');
       this.maskSvc.mask.d3.selectAll('circle').attr('opacity', 0);
-      return svgSave.svgAsPngUri(this.maskSvc.mask.dom.children[0], { width: 1164, height: 874, top: 38, left: 43, encoderOptions: 0.0 })
+      return svgSave.svgAsPngUri(this.maskSvc.mask.dom.children[0], { width: this.dimensions.width, height: this.dimensions.height, top: 38, left: 43, encoderOptions: 0.0 })
         .then(uri => {
           Jimp.read(this.maskSvc.loadedMaskUrl(), (err, originalMask) => {
             Jimp.read(uri, (err, image) => {


### PR DESCRIPTION
Kind of hacky but it works for the new imgs2 series if you load up the source via Image URL.  It will automatically set the correct canvas dimensions depending on if you're making imgs/ or imgs2/ masks.

Known issues:

- Did not add imgs2 to the image selector (where you can just type the number and "Go")
- Can't load existing mask